### PR TITLE
Add blobqueue.Must to ease unsafe use of Queue (panic when error)

### DIFF
--- a/must.go
+++ b/must.go
@@ -1,0 +1,63 @@
+package blobqueue
+
+// Must wraps a Queue with methods that panic instead of returning error.
+type Must struct {
+	Queue Queue
+}
+
+// List transforms errors from Queue.List into panic.
+func (q Must) List() [][]byte {
+	list, err := q.Queue.List()
+	if err != nil {
+		panic(err)
+	}
+	return list
+}
+
+// Push transforms errors from Queue.Push into panic.
+func (q Must) Push(val []byte) {
+	if err := q.Queue.Push(val); err != nil {
+		panic(err)
+	}
+}
+
+// Unshift transforms errors from Queue.Unshift into panic.
+func (q Must) Unshift(val []byte) {
+	if err := q.Queue.Unshift(val); err != nil {
+		panic(err)
+	}
+}
+
+// Unshift transforms errors from Queue.Unshift into panic.
+func (q Must) Pop() []byte {
+	val, err := q.Queue.Pop()
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+// Shift transforms errors from Queue.Shift into panic.
+func (q Must) Shift() []byte {
+	val, err := q.Queue.Shift()
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+// Len transforms errors from Queue.Len into panic.
+func (q Must) Len() int {
+	l, err := q.Queue.Len()
+	if err != nil {
+		panic(err)
+	}
+	return l
+}
+
+// Empty transforms errors from Queue.Empty into panic.
+func (q Must) Empty() {
+	if err := q.Queue.Empty(); err != nil {
+		panic(err)
+	}
+}

--- a/must_test.go
+++ b/must_test.go
@@ -10,14 +10,17 @@ import (
 func ExampleMust() {
 	q := blobqueue.Must{new(memory.Queue)}
 	fmt.Println(q.Len())
-	q.Push([]byte("AA"))
+	q.Unshift([]byte("AA"))
+	q.Push([]byte("BB"))
+	fmt.Printf("%s\n", q.List())
 	fmt.Println(q.Len())
-	fmt.Printf("%s\n", q.Pop())
+	fmt.Printf("%s %s\n", q.Pop(), q.Shift())
 	fmt.Println(q.Len())
 
 	// Output:
 	// 0
-	// 1
-	// AA
+	// [AA BB]
+	// 2
+	// BB AA
 	// 0
 }

--- a/must_test.go
+++ b/must_test.go
@@ -1,0 +1,23 @@
+package blobqueue_test
+
+import (
+	"fmt"
+
+	"github.com/blueboardio/go-blobqueue"
+	"github.com/blueboardio/go-blobqueue/memory"
+)
+
+func ExampleMust() {
+	q := blobqueue.Must{new(memory.Queue)}
+	fmt.Println(q.Len())
+	q.Push([]byte("AA"))
+	fmt.Println(q.Len())
+	fmt.Printf("%s\n", q.Pop())
+	fmt.Println(q.Len())
+
+	// Output:
+	// 0
+	// 1
+	// AA
+	// 0
+}

--- a/must_test.go
+++ b/must_test.go
@@ -2,6 +2,7 @@ package blobqueue_test
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/blueboardio/go-blobqueue"
 	"github.com/blueboardio/go-blobqueue/memory"
@@ -23,4 +24,27 @@ func ExampleMust() {
 	// 2
 	// BB AA
 	// 0
+}
+
+func expectPanic(t *testing.T, msg string) {
+	if e := recover(); e != nil {
+		errMsg := e.(error).Error()
+		if errMsg != msg {
+			t.Errorf("got panic %v, expected %q", e, msg)
+		}
+	} else {
+		t.Errorf("expected panic %q, got nothing", msg)
+	}
+}
+
+func TestMustPop(t *testing.T) {
+	q := blobqueue.Must{new(memory.Queue)}
+	defer expectPanic(t, blobqueue.ErrQueueIsEmtpy.Error())
+	_ = q.Pop()
+}
+
+func TestMustShift(t *testing.T) {
+	q := blobqueue.Must{new(memory.Queue)}
+	defer expectPanic(t, blobqueue.ErrQueueIsEmtpy.Error())
+	_ = q.Shift()
 }

--- a/queuetesting/failing.go
+++ b/queuetesting/failing.go
@@ -1,0 +1,74 @@
+package queuetesting
+
+import (
+	"github.com/blueboardio/go-blobqueue"
+)
+
+// Failing wraps a queue to mock errors returned by a blobqueue.Queue.
+type Failing struct {
+	blobqueue.Queue
+	NextError error
+}
+
+// List implements Queue interface.
+func (q Failing) List() ([][]byte, error) {
+	if err := q.NextError; err != nil {
+		q.NextError = nil
+		return nil, err
+	}
+	return q.Queue.List()
+}
+
+// Push implements Queue interface.
+func (q Failing) Push(val []byte) error {
+	if err := q.NextError; err != nil {
+		q.NextError = nil
+		return err
+	}
+	return q.Queue.Push(val)
+}
+
+// Unshift implements Queue interface.
+func (q Failing) Unshift(val []byte) error {
+	if err := q.NextError; err != nil {
+		q.NextError = nil
+		return err
+	}
+	return q.Queue.Unshift(val)
+}
+
+// Pop implements Queue interface.
+func (q Failing) Pop() ([]byte, error) {
+	if err := q.NextError; err != nil {
+		q.NextError = nil
+		return nil, err
+	}
+	return q.Queue.Pop()
+}
+
+// Shift implements Queue interface.
+func (q Failing) Shift() ([]byte, error) {
+	if err := q.NextError; err != nil {
+		q.NextError = nil
+		return nil, err
+	}
+	return q.Queue.Shift()
+}
+
+// Len implements Queue interface.
+func (q Failing) Len() (int, error) {
+	if err := q.NextError; err != nil {
+		q.NextError = nil
+		return 0, err
+	}
+	return q.Queue.Len()
+}
+
+// Empty implements Queue interface.
+func (q Failing) Empty() error {
+	if err := q.NextError; err != nil {
+		q.NextError = nil
+		return err
+	}
+	return q.Queue.Empty()
+}


### PR DESCRIPTION
Add type `blobqueue.Must` to wrap `Queue` but remove `error` from return values (panic if non-`nil`).