### PR TITLE
Feature: typedqueue

### DIFF
--- a/typedqueue/go.mod
+++ b/typedqueue/go.mod
@@ -1,0 +1,6 @@
+module github.com/blueboardio/go-blobqueue/typedqueue
+
+require (
+	github.com/blueboardio/go-blobqueue v0.1.1
+	github.com/stretchr/testify v1.2.2
+)

--- a/typedqueue/go.sum
+++ b/typedqueue/go.sum
@@ -1,0 +1,8 @@
+github.com/blueboardio/go-blobqueue v0.1.1 h1:5kY7Xle9bW5N3Q4LG6snaLkGx/t+wo5w6Xoua6T/ftg=
+github.com/blueboardio/go-blobqueue v0.1.1/go.mod h1:zzMMUQG5+EVRK04/xyZZMmG4sF2sTeGbz1k2Gz8wBRE=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/typedqueue/queue.go
+++ b/typedqueue/queue.go
@@ -16,8 +16,8 @@ type Value struct {
 
 type Queue struct {
 	q    blobqueue.Queue
-	zero Value
 	t    reflect.Type
+	zero encoding.BinaryMarshaler
 }
 
 // New wraps a queue to store any value of the same type that implements
@@ -30,7 +30,7 @@ func New(q blobqueue.Queue, zeroValue encoding.BinaryMarshaler) *Queue {
 	// Checks of the contract for values
 	_ = decodeValue(t, encodeValue(t, zeroValue))
 
-	return &Queue{q: q, t: t}
+	return &Queue{q: q, t: t, zero: zeroValue}
 }
 
 // Len returns the length of the queue.

--- a/typedqueue/queue.go
+++ b/typedqueue/queue.go
@@ -1,0 +1,120 @@
+// Package typedqueue wraps a blobqueue, with serialization and runtime type checking of values
+package typedqueue
+
+import (
+	"encoding"
+	"fmt"
+	"reflect"
+
+	blobqueue "github.com/blueboardio/go-blobqueue"
+)
+
+type Value struct {
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
+}
+
+type Queue struct {
+	q    blobqueue.Queue
+	zero Value
+	t    reflect.Type
+}
+
+// New wraps a queue to store any value of the same type that implements
+// encoding.BinaryMarshaler and encoding.BinaryUnmarshaler.
+//
+// Any marshaling/unmarshaling error is unexpected and raises a panic.
+// So any error returned by the queue methods come from the original queue.
+func New(q blobqueue.Queue, zeroValue encoding.BinaryMarshaler) *Queue {
+	t := reflect.TypeOf(zeroValue)
+	// Checks of the contract for values
+	_ = decodeValue(t, encodeValue(t, zeroValue))
+
+	return &Queue{q: q, t: t}
+}
+
+// Len returns the length of the queue.
+func (q *Queue) Len() (int, error) {
+	return q.q.Len()
+}
+
+// Empty clears the queue.
+func (q *Queue) Empty() error {
+	return q.q.Empty()
+}
+
+func encodeValue(t reflect.Type, v encoding.BinaryMarshaler) []byte {
+	// Runtime check of type
+	// This could be removed from production builds
+	if reflect.TypeOf(v) != t {
+		panic(fmt.Errorf("unexpected value of type %T", v))
+	}
+
+	b, err := v.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func decodeValue(t reflect.Type, b []byte) interface{} {
+	v := reflect.New(t)
+	if err := v.Interface().(encoding.BinaryUnmarshaler).UnmarshalBinary(b); err != nil {
+		panic(err)
+	}
+	return v.Elem().Interface()
+}
+
+func decodeSlice(t reflect.Type, src [][]byte) interface{} {
+	if len(src) == 0 {
+		// nil slice
+		return reflect.New(reflect.SliceOf(t)).Elem().Interface()
+	}
+	sl := reflect.MakeSlice(reflect.SliceOf(t), len(src), len(src))
+	for i, b := range src {
+		err := sl.Index(i).Addr().Interface().(encoding.BinaryUnmarshaler).UnmarshalBinary(b)
+		if err != nil {
+			panic(fmt.Errorf("index %d: %v", i, err))
+		}
+	}
+	return sl.Interface()
+}
+
+// Push appends the queue with a new elem (val).
+func (q *Queue) Push(val encoding.BinaryMarshaler) error {
+	return q.q.Push(encodeValue(q.t, val))
+}
+
+// Unshift add a new elem at the beggining of the queue.
+func (q *Queue) Unshift(val encoding.BinaryMarshaler) error {
+	return q.q.Unshift(encodeValue(q.t, val))
+}
+
+// Pop deletes the last element of the queue, it returns this precise element.
+// If the queue is empty it returns error ErrQueueIsEmtpy.
+func (q *Queue) Pop() (encoding.BinaryMarshaler, error) {
+	b, err := q.q.Pop()
+	if err != nil {
+		return q.zero, err
+	}
+	return decodeValue(q.t, b).(encoding.BinaryMarshaler), nil
+}
+
+// Shift deletes the first element of the queue, it returns this precise element.
+// If the queue is empty it returns error ErrQueueIsEmtpy.
+func (q *Queue) Shift() (encoding.BinaryMarshaler, error) {
+	b, err := q.q.Shift()
+	if err != nil {
+		return q.zero, err
+	}
+	return decodeValue(q.t, b).(encoding.BinaryMarshaler), nil
+}
+
+// List returns all the items of the queue as a slice of values.
+func (q *Queue) List() (interface{}, error) {
+	src, err := q.q.List()
+	if err != nil {
+		return decodeSlice(q.t, nil), err
+	}
+	return decodeSlice(q.t, src), nil
+}

--- a/typedqueue/queue_test.go
+++ b/typedqueue/queue_test.go
@@ -48,24 +48,28 @@ func TestQueue(t *testing.T) {
 	assert := assert.New(t)
 	q := typedqueue.New(&memory.Queue{}, Uint64(0))
 
-	li, err := q.List()
-	assert.NoError(err)
-	assert.Equal(li, []Uint64(nil))
+	assertEmpty := func(q *typedqueue.Queue) {
+		l, err := q.Len()
+		assert.NoError(err)
+		assert.Equal(l, 0)
 
-	n, err := q.Pop()
-	assert.Error(err, blobqueue.ErrQueueIsEmtpy)
-	assert.Equal(Uint64(0), n) // check zero value
+		li, err := q.List()
+		assert.NoError(err)
+		assert.Equal(li, []Uint64(nil))
 
-	n, err = q.Shift()
-	assert.Error(err, blobqueue.ErrQueueIsEmtpy)
-	assert.Equal(Uint64(0), n) // check zero value
+		n, err := q.Pop()
+		assert.Error(err, blobqueue.ErrQueueIsEmtpy)
+		assert.Equal(Uint64(0), n) // check zero value
 
-	l, err := q.Len()
-	assert.NoError(err)
-	assert.Equal(l, 0)
+		n, err = q.Shift()
+		assert.Error(err, blobqueue.ErrQueueIsEmtpy)
+		assert.Equal(Uint64(0), n) // check zero value
+	}
+
+	assertEmpty(q)
 
 	q.Push(Uint64(1))
-	l, err = q.Len()
+	l, err := q.Len()
 	assert.NoError(err)
 	assert.Equal(l, 1)
 
@@ -79,11 +83,11 @@ func TestQueue(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(l, 3)
 
-	li, err = q.List()
+	li, err := q.List()
 	assert.NoError(err)
 	assert.Equal(li, []Uint64{1, 2, 3})
 
-	n, err = q.Pop()
+	n, err := q.Pop()
 	assert.NoError(err)
 	assert.Equal(n, Uint64(3))
 
@@ -101,4 +105,10 @@ func TestQueue(t *testing.T) {
 	l, err = q.Len()
 	assert.NoError(err)
 	assert.Equal(l, 1)
+
+	n, err = q.Pop()
+	assert.NoError(err)
+	assert.Equal(n, Uint64(2))
+
+	assertEmpty(q)
 }

--- a/typedqueue/queue_test.go
+++ b/typedqueue/queue_test.go
@@ -3,6 +3,7 @@ package typedqueue_test
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,20 @@ func (u *Uint64) UnmarshalBinary(b []byte) error {
 	}
 	*u = Uint64(tmp)
 	return nil
+}
+
+func Example() {
+	q := typedqueue.New(&memory.Queue{}, Uint64(0))
+
+	_ = q.Push(Uint64(1))
+	_ = q.Push(Uint64(2))
+	_ = q.Push(Uint64(3))
+
+	li, _ := q.List()
+	fmt.Printf("%#v\n", li)
+
+	// Output:
+	// []typedqueue_test.Uint64{0x1, 0x2, 0x3}
 }
 
 func TestQueue(t *testing.T) {

--- a/typedqueue/queue_test.go
+++ b/typedqueue/queue_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/blueboardio/go-blobqueue"
 	"github.com/blueboardio/go-blobqueue/memory"
 	"github.com/blueboardio/go-blobqueue/typedqueue"
 )
@@ -51,6 +52,14 @@ func TestQueue(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(li, []Uint64(nil))
 
+	n, err := q.Pop()
+	assert.Error(err, blobqueue.ErrQueueIsEmtpy)
+	assert.Equal(Uint64(0), n) // check zero value
+
+	n, err = q.Shift()
+	assert.Error(err, blobqueue.ErrQueueIsEmtpy)
+	assert.Equal(Uint64(0), n) // check zero value
+
 	l, err := q.Len()
 	assert.NoError(err)
 	assert.Equal(l, 0)
@@ -74,7 +83,7 @@ func TestQueue(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(li, []Uint64{1, 2, 3})
 
-	n, err := q.Pop()
+	n, err = q.Pop()
 	assert.NoError(err)
 	assert.Equal(n, Uint64(3))
 

--- a/typedqueue/queue_test.go
+++ b/typedqueue/queue_test.go
@@ -1,0 +1,80 @@
+package typedqueue_test
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/blueboardio/go-blobqueue/memory"
+	"github.com/blueboardio/go-blobqueue/typedqueue"
+)
+
+type Uint64 uint64
+
+func (u Uint64) MarshalBinary() ([]byte, error) {
+	b := make([]byte, binary.MaxVarintLen64)
+	binary.PutUvarint(b, uint64(u))
+	return b, nil
+}
+
+func (u *Uint64) UnmarshalBinary(b []byte) error {
+	tmp, n := binary.Uvarint(b)
+	if n <= 0 {
+		return errors.New("invalid data")
+	}
+	*u = Uint64(tmp)
+	return nil
+}
+
+func TestQueue(t *testing.T) {
+	assert := assert.New(t)
+	q := typedqueue.New(&memory.Queue{}, Uint64(0))
+
+	li, err := q.List()
+	assert.NoError(err)
+	assert.Equal(li, []Uint64(nil))
+
+	l, err := q.Len()
+	assert.NoError(err)
+	assert.Equal(l, 0)
+
+	q.Push(Uint64(1))
+	l, err = q.Len()
+	assert.NoError(err)
+	assert.Equal(l, 1)
+
+	q.Push(Uint64(2))
+	l, err = q.Len()
+	assert.NoError(err)
+	assert.Equal(l, 2)
+
+	q.Push(Uint64(3))
+	l, err = q.Len()
+	assert.NoError(err)
+	assert.Equal(l, 3)
+
+	li, err = q.List()
+	assert.NoError(err)
+	assert.Equal(li, []Uint64{1, 2, 3})
+
+	n, err := q.Pop()
+	assert.NoError(err)
+	assert.Equal(n, Uint64(3))
+
+	li, err = q.List()
+	assert.NoError(err)
+	assert.Equal(li, []Uint64{1, 2})
+
+	n, err = q.Shift()
+	assert.NoError(err)
+	assert.Equal(n, Uint64(1))
+
+	li, err = q.List()
+	assert.NoError(err)
+	assert.Equal(li, []Uint64{2})
+	l, err = q.Len()
+	assert.NoError(err)
+	assert.Equal(l, 1)
+}


### PR DESCRIPTION
Add package `typedqueue`, wrapping a `blobqueue.Queue`, but handling serialization (using using `encoding.BinaryMarshaler`, `encoding.BinaryUnmarshaler`) and runtime type checks of values put in the queue.

This is a package built on top of `blobqueue` and it exposes a different interface. So it has its own `go.mod`.