### PR TITLE
WIP: Peek method

### DIFF
--- a/memory/memory.go
+++ b/memory/memory.go
@@ -44,6 +44,13 @@ func (q *Queue) Shift() ([]byte, error) {
 	return save, nil
 }
 
+func (q Queue) Peek() ([]byte, error) {
+	if len(q) == 0 {
+		return nil, blobqueue.ErrQueueIsEmpty
+	}
+	return q[0], nil
+}
+
 // Len implements Queue interface
 func (q Queue) Len() (int, error) {
 	return len(q), nil

--- a/must.go
+++ b/must.go
@@ -46,6 +46,15 @@ func (q Must) Shift() []byte {
 	return val
 }
 
+// Peek transforms errors from Queue.Peek into panic.
+func (q Must) Peek() []byte {
+	val, err := q.Queue.Peek()
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Len transforms errors from Queue.Len into panic.
 func (q Must) Len() int {
 	l, err := q.Queue.Len()

--- a/queue.go
+++ b/queue.go
@@ -26,6 +26,10 @@ type Queue interface {
 	// If the queue is empty it returns error ErrQueueIsEmpty.
 	Shift() ([]byte, error)
 
+	// Peek returns the first element of the list without removing it from the queue.
+	// If the queue is empty it returns error ErrQueueIsEmpty.
+	Peek() ([]byte, error)
+
 	// Len returns the length of the queue.
 	Len() (int, error)
 	// Empty clears the queue.
@@ -84,6 +88,13 @@ func (q *safeQueue) Shift() ([]byte, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	return q.q.Shift()
+}
+
+// Peek implements Queue interface
+func (q *safeQueue) Peek() ([]byte, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.q.Peek()
 }
 
 // Len implements Queue interface

--- a/queuebinary/binary.go
+++ b/queuebinary/binary.go
@@ -36,3 +36,11 @@ func Shift(q blobqueue.Queue, v encoding.BinaryUnmarshaler) error {
 	}
 	return v.UnmarshalBinary(b)
 }
+
+func Peek(q blobqueue.Queue, v encoding.BinaryUnmarshaler) error {
+	b, err := q.Peek()
+	if err != nil {
+		return err
+	}
+	return v.UnmarshalBinary(b)
+}

--- a/queuebinary/binary_test.go
+++ b/queuebinary/binary_test.go
@@ -45,6 +45,14 @@ func TestPushPop(t *testing.T) {
 	}
 
 	var out S
+	err = queuebinary.Peek(q, &out)
+	if err != nil {
+		t.Fatal("Peek should work")
+	}
+	if out != "abc" {
+		t.Fatal("Peek: Bad value")
+	}
+
 	err = queuebinary.Pop(q, &out)
 	if err != nil {
 		t.Fatal("Pop should work")

--- a/queuejson/json.go
+++ b/queuejson/json.go
@@ -44,3 +44,13 @@ func Shift(q blobqueue.Queue, v interface{}) error {
 	}
 	return json.Unmarshal(b, v)
 }
+
+// Peek gets the head of the queue without removing it and deserialize it as JSON into v.
+// v must be a pointer (see json.Unmarshal).
+func Peek(q blobqueue.Queue, v interface{}) error {
+	b, err := q.Peek()
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
+}

--- a/queuejson/json_test.go
+++ b/queuejson/json_test.go
@@ -36,6 +36,14 @@ func TestPushPop(t *testing.T) {
 	}
 
 	var out interface{}
+	err = queuejson.Peek(q, &out)
+	if err != nil {
+		t.Fatal("Peek should work")
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("Peek: Bad value: %#v vs %#v", in, out)
+	}
+
 	err = queuejson.Pop(q, &out)
 	if err != nil {
 		t.Fatal("Pop should work")

--- a/queuemsgpack/go.mod
+++ b/queuemsgpack/go.mod
@@ -3,6 +3,6 @@ module github.com/blueboardio/go-blobqueue/queuemsgpack
 go 1.14
 
 require (
-	github.com/blueboardio/go-blobqueue v0.4.0
+	github.com/blueboardio/go-blobqueue v0.4.1-0.20200915164425-df0e7a88e75e
 	github.com/vmihailenco/msgpack/v4 v4.3.12
 )

--- a/queuemsgpack/go.sum
+++ b/queuemsgpack/go.sum
@@ -1,5 +1,7 @@
 github.com/blueboardio/go-blobqueue v0.4.0 h1:iX5XoS0LbjR6M5N5wS8mAwMX9SfiKf6ASRApeoB1YIo=
 github.com/blueboardio/go-blobqueue v0.4.0/go.mod h1:2++DFT2J51nJW5y262s5LGZzu0ctmuZlSofCHK748UE=
+github.com/blueboardio/go-blobqueue v0.4.1-0.20200915164425-df0e7a88e75e h1:03aZRbWAqNjL9fdjAtIgOu8yvZisxuUxDvOQODxKLe4=
+github.com/blueboardio/go-blobqueue v0.4.1-0.20200915164425-df0e7a88e75e/go.mod h1:2++DFT2J51nJW5y262s5LGZzu0ctmuZlSofCHK748UE=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=

--- a/queuemsgpack/q.go
+++ b/queuemsgpack/q.go
@@ -48,3 +48,13 @@ func Shift(q blobqueue.Queue, v interface{}) error {
 	}
 	return msgpack.Unmarshal(b, v)
 }
+
+// Peek returns the head of the queue without removing it and deserialize it as MessagePack into v.
+// v must be a pointer (see msgpack.Unmarshal).
+func Peek(q blobqueue.Queue, v interface{}) error {
+	b, err := q.Peek()
+	if err != nil {
+		return err
+	}
+	return msgpack.Unmarshal(b, v)
+}

--- a/queuemsgpack/q_test.go
+++ b/queuemsgpack/q_test.go
@@ -35,6 +35,15 @@ func TestPushPop(t *testing.T) {
 		t.Fatal("Len should be 1")
 	}
 
+	var outPeek interface{}
+	err = queuemsgpack.Peek(q, &outPeek)
+	if err != nil {
+		t.Fatal("Peek should work")
+	}
+	if !reflect.DeepEqual(in, outPeek) {
+		t.Fatalf("Peek: Bad value: %#v vs %#v", in, outPeek)
+	}
+
 	var out interface{}
 	err = queuemsgpack.Pop(q, &out)
 	if err != nil {

--- a/queueredis/go.mod
+++ b/queueredis/go.mod
@@ -3,7 +3,7 @@ module github.com/blueboardio/go-blobqueue/queueredis
 go 1.12
 
 require (
-	github.com/blueboardio/go-blobqueue v0.3.1
+	github.com/blueboardio/go-blobqueue v0.4.1-0.20200915163728-87adbb26c512
 	github.com/go-redis/redis/v7 v7.4.0
 	github.com/onsi/ginkgo v1.13.0 // indirect
 	github.com/stretchr/testify v1.2.2

--- a/queueredis/go.sum
+++ b/queueredis/go.sum
@@ -1,5 +1,9 @@
 github.com/blueboardio/go-blobqueue v0.3.1 h1:lD/5BOndG3aFPSDLvyMYARSXqU5ZJSKOtH9LeLq9FRo=
 github.com/blueboardio/go-blobqueue v0.3.1/go.mod h1:2++DFT2J51nJW5y262s5LGZzu0ctmuZlSofCHK748UE=
+github.com/blueboardio/go-blobqueue v0.4.1-0.20200915160536-44d3b8029219 h1:/D4v6Z7GuHgcnANHyttqe4x8rcjccAwK1Eeq/TqN3dA=
+github.com/blueboardio/go-blobqueue v0.4.1-0.20200915160536-44d3b8029219/go.mod h1:2++DFT2J51nJW5y262s5LGZzu0ctmuZlSofCHK748UE=
+github.com/blueboardio/go-blobqueue v0.4.1-0.20200915163728-87adbb26c512 h1:ViYyW0smiH+ievOHS7yb6QjJZcYbmZ+Bnx/Lza632d8=
+github.com/blueboardio/go-blobqueue v0.4.1-0.20200915163728-87adbb26c512/go.mod h1:2++DFT2J51nJW5y262s5LGZzu0ctmuZlSofCHK748UE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/queueredis/redis.go
+++ b/queueredis/redis.go
@@ -62,6 +62,20 @@ func (q Queue) Shift() ([]byte, error) {
 	return removeBase(q.client.LPop, q.key)
 }
 
+// Peek implements `Queue` interface. It returns the first elem of the Redis list without removing it.
+// It returns ErrQueueIsEmpty if the list is empty.
+func (q Queue) Peek() ([]byte, error) {
+	cmd := q.client.LRange(q.key, 0, 0)
+	if cmd.Err() != nil {
+		return nil, cmd.Err()
+	}
+	val := cmd.Val()
+	if len(val) == 0 {
+		return nil, blobqueue.ErrQueueIsEmpty
+	}
+	return []byte(val[0]), nil
+}
+
 // Len implements `Queue` interface. It returns the length of the Redis list.
 func (q Queue) Len() (int, error) {
 	cmd := q.client.LLen(q.key)

--- a/queuetesting/testing.go
+++ b/queuetesting/testing.go
@@ -123,6 +123,9 @@ func RunTests(t *testing.T, queue blobqueue.Queue, shouldAlwaysFail bool) {
 			case peekAction:
 				var val []byte
 				val, err = suite.Queue.Peek()
+				if shouldAlwaysFail {
+					action.ExpectVal = nil
+				}
 				assert.Equal(t, action.ExpectVal, val, infoMsg)
 			default:
 				t.Fatalf("Your test suite has unexpected action type at index %d", i)

--- a/queuetesting/testing.go
+++ b/queuetesting/testing.go
@@ -16,6 +16,7 @@ const (
 	popAction
 	shiftAction
 	emptyAction
+	peekAction
 )
 
 type action struct {
@@ -38,6 +39,8 @@ var actions = []action{
 	{Type: listAction, ExpectList: nil, ShouldErr: false},
 	{Type: pushAction, Val: []byte("elem 1"), ShouldErr: false},
 	{Type: lenAction, ExpectLen: 1, ShouldErr: false},
+	{Type: peekAction, ExpectVal: []byte("elem 1"), ShouldErr: false},
+	{Type: lenAction, ExpectLen: 1, ShouldErr: false},
 	{Type: unshiftAction, Val: []byte("elem 0"), ShouldErr: false},
 	{Type: lenAction, ExpectLen: 2, ShouldErr: false},
 	{Type: pushAction, Val: []byte("elem 2"), ShouldErr: false},
@@ -56,6 +59,7 @@ var actions = []action{
 	{Type: listAction, ExpectList: nil, ShouldErr: false},
 	{Type: popAction, ShouldErr: true, ExpectErr: blobqueue.ErrQueueIsEmpty, ExpectVal: nil},
 	{Type: shiftAction, ShouldErr: true, ExpectErr: blobqueue.ErrQueueIsEmpty, ExpectVal: nil},
+	{Type: peekAction, ShouldErr: true, ExpectErr: blobqueue.ErrQueueIsEmpty, ExpectVal: nil},
 	{Type: lenAction, ExpectLen: 0, ShouldErr: false},
 	{Type: listAction, ExpectList: nil, ShouldErr: false},
 }
@@ -116,6 +120,10 @@ func RunTests(t *testing.T, queue blobqueue.Queue, shouldAlwaysFail bool) {
 			case emptyAction:
 				err = suite.Queue.Empty()
 				break
+			case peekAction:
+				var val []byte
+				val, err = suite.Queue.Peek()
+				assert.Equal(t, action.ExpectVal, val, infoMsg)
 			default:
 				t.Fatalf("Your test suite has unexpected action type at index %d", i)
 			}

--- a/typedqueue/go.mod
+++ b/typedqueue/go.mod
@@ -3,6 +3,6 @@ module github.com/blueboardio/go-blobqueue/typedqueue
 go 1.14
 
 require (
-	github.com/blueboardio/go-blobqueue v0.0.0-20200623115943-2c847ec7b2f9
+	github.com/blueboardio/go-blobqueue v0.4.1-0.20200915165141-94f069d78843
 	github.com/stretchr/testify v1.2.2
 )

--- a/typedqueue/go.sum
+++ b/typedqueue/go.sum
@@ -1,5 +1,7 @@
 github.com/blueboardio/go-blobqueue v0.0.0-20200623115943-2c847ec7b2f9 h1:hC4lqcjdnebXpdeY0kJaas4PJPp+YVYy/JWBaJEIVNU=
 github.com/blueboardio/go-blobqueue v0.0.0-20200623115943-2c847ec7b2f9/go.mod h1:2++DFT2J51nJW5y262s5LGZzu0ctmuZlSofCHK748UE=
+github.com/blueboardio/go-blobqueue v0.4.1-0.20200915165141-94f069d78843 h1:iLIC5ye7GllnJdCYxWyAHUqZnsdkh0NiXVLJ21FoEaw=
+github.com/blueboardio/go-blobqueue v0.4.1-0.20200915165141-94f069d78843/go.mod h1:2++DFT2J51nJW5y262s5LGZzu0ctmuZlSofCHK748UE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/typedqueue/queue.go
+++ b/typedqueue/queue.go
@@ -110,6 +110,14 @@ func (q *Queue) Shift() (encoding.BinaryMarshaler, error) {
 	return decodeValue(q.t, b).(encoding.BinaryMarshaler), nil
 }
 
+func (q *Queue) Peek() (encoding.BinaryMarshaler, error) {
+	b, err := q.q.Peek()
+	if err != nil {
+		return q.zero, err
+	}
+	return decodeValue(q.t, b).(encoding.BinaryMarshaler), nil
+}
+
 // List returns all the items of the queue as a slice of values.
 func (q *Queue) List() (interface{}, error) {
 	src, err := q.q.List()

--- a/typedqueue/queue_test.go
+++ b/typedqueue/queue_test.go
@@ -73,6 +73,10 @@ func TestQueue(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(l, 1)
 
+	n, err := q.Peek()
+	assert.NoError(err)
+	assert.Equal(n, Uint64(1))
+
 	q.Push(Uint64(2))
 	l, err = q.Len()
 	assert.NoError(err)
@@ -87,7 +91,7 @@ func TestQueue(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(li, []Uint64{1, 2, 3})
 
-	n, err := q.Pop()
+	n, err = q.Pop()
 	assert.NoError(err)
 	assert.Equal(n, Uint64(3))
 


### PR DESCRIPTION
This MR add the `Peek` method to the `Queue` interface. Peek should return the first of its queue without removing it, like Pop does.

This is useful when you need to work on the next element of your queue but don't want to modify the state.

Implementation and tests in all subpackages are done.